### PR TITLE
修复单词本问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 .idea
 cookie
 Test.php
-src/info-bak.plist
+src/info copy.plist
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.log
 .idea
 cookie
+Test.php
+src/info-bak.plist

--- a/src/YoudaoTranslate.php
+++ b/src/YoudaoTranslate.php
@@ -326,7 +326,7 @@ class YoudaoTranslate
             ->arg($arg)
             ->mod('cmd', '🔊' . $this->pronounce, $this->pronounce)
             ->mod('alt', '🔊' . $this->pronounce, $this->pronounce)
-            ->mod('ctrl', '📝 加入生词本', implode('|', [$this->pronounce, $this->phonetic, $title]))
+            ->mod('ctrl', '📝 加入生词本', implode('|', [$subtitle, '请选择分组']))
             ->icon($icon)
             ->text('copy', $title);
 

--- a/src/info.plist
+++ b/src/info.plist
@@ -242,7 +242,7 @@
 			<key>uid</key>
 			<string>CAF59F43-6C28-47BF-B3DA-1A65C2198F2F</string>
 			<key>version</key>
-			<integer>2</integer>
+			<integer>3</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -305,7 +305,7 @@
 			<key>uid</key>
 			<string>1631393E-5B53-4C8B-AF64-A04B687438DF</string>
 			<key>version</key>
-			<integer>1</integer>
+			<integer>2</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -321,7 +321,7 @@
 				<key>hotkey</key>
 				<integer>49</integer>
 				<key>hotmod</key>
-				<integer>262144</integer>
+				<integer>524288</integer>
 				<key>hotstring</key>
 				<string>Space</string>
 				<key>leftcursor</key>
@@ -345,6 +345,8 @@
 				<false/>
 				<key>alfredfiltersresultsmatchmode</key>
 				<integer>0</integer>
+				<key>argumenttreatemptyqueryasnil</key>
+				<false/>
 				<key>argumenttrimmode</key>
 				<integer>0</integer>
 				<key>argumenttype</key>
@@ -394,7 +396,7 @@ echo $translator-&gt;translate($argv[1]);
 			<key>uid</key>
 			<string>8FE8475E-6310-49A4-967E-D6CCE73A86AC</string>
 			<key>version</key>
-			<integer>2</integer>
+			<integer>3</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -584,6 +586,8 @@ if (empty($username) || empty($password)) {
 				<true/>
 				<key>alfredfiltersresultsmatchmode</key>
 				<integer>0</integer>
+				<key>argumenttreatemptyqueryasnil</key>
+				<false/>
 				<key>argumenttrimmode</key>
 				<integer>0</integer>
 				<key>argumenttype</key>
@@ -630,7 +634,7 @@ echo $updater-&gt;fetchReleases();
 			<key>uid</key>
 			<string>224556A8-701F-43C1-B08A-A973D9A7DB58</string>
 			<key>version</key>
-			<integer>2</integer>
+			<integer>3</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -848,7 +852,7 @@ echo $updater-&gt;fetchReleases();
 		<key>youdao_appkey</key>
 		<string></string>
 		<key>youdao_secret</key>
-		<string></string>
+		<string></string>>
 	</dict>
 	<key>variablesdontexport</key>
 	<array>

--- a/src/info.plist
+++ b/src/info.plist
@@ -142,7 +142,7 @@
 			</dict>
 			<dict>
 				<key>destinationuid</key>
-				<string>698ED0AA-6A32-4AA5-B9B4-94F88D53AE40</string>
+				<string>F1565205-CE7B-4880-A3D5-5FAA0609C9C5</string>
 				<key>modifiers</key>
 				<integer>262144</integer>
 				<key>modifiersubtext</key>
@@ -208,6 +208,19 @@
 			<dict>
 				<key>destinationuid</key>
 				<string>8FE8475E-6310-49A4-967E-D6CCE73A86AC</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>F1565205-CE7B-4880-A3D5-5FAA0609C9C5</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>698ED0AA-6A32-4AA5-B9B4-94F88D53AE40</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -492,6 +505,71 @@ afplay "$voice"</string>
 		<dict>
 			<key>config</key>
 			<dict>
+				<key>alfredfiltersresults</key>
+				<false/>
+				<key>alfredfiltersresultsmatchmode</key>
+				<integer>0</integer>
+				<key>argumenttreatemptyqueryasnil</key>
+				<true/>
+				<key>argumenttrimmode</key>
+				<integer>0</integer>
+				<key>argumenttype</key>
+				<integer>0</integer>
+				<key>escaping</key>
+				<integer>100</integer>
+				<key>queuedelaycustom</key>
+				<integer>3</integer>
+				<key>queuedelayimmediatelyinitially</key>
+				<true/>
+				<key>queuedelaymode</key>
+				<integer>0</integer>
+				<key>queuemode</key>
+				<integer>1</integer>
+				<key>runningsubtext</key>
+				<string>同步分组中...</string>
+				<key>script</key>
+				<string>&lt;?php
+
+require('WordBook.php');
+
+$query = $argv[1];
+
+$username = getenv('netease_username');
+$password = getenv('netease_password');
+
+
+if (empty($username) || empty($password)) {
+	echo '请设置用户名和密码';
+} else {
+	$wordBook = new WordBook($username, $password);
+
+	echo $wordBook-&gt;books($query);
+}
+
+?&gt;</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>subtext</key>
+				<string></string>
+				<key>title</key>
+				<string>请选择分组</string>
+				<key>type</key>
+				<integer>1</integer>
+				<key>withspace</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.scriptfilter</string>
+			<key>uid</key>
+			<string>F1565205-CE7B-4880-A3D5-5FAA0609C9C5</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
 				<key>concurrently</key>
 				<false/>
 				<key>escaping</key>
@@ -510,9 +588,7 @@ if (empty($username) || empty($password)) {
 } else {
 	$wordBook = new WordBook($username, $password);
 
-	list($word, $phonetic, $desc) = explode('|', $query);
-
-	echo $wordBook-&gt;add($word, $phonetic, $desc);
+	echo $wordBook-&gt;add($query);
 
 }</string>
 				<key>scriptargtype</key>
@@ -778,9 +854,9 @@ echo $updater-&gt;fetchReleases();
 		<key>698ED0AA-6A32-4AA5-B9B4-94F88D53AE40</key>
 		<dict>
 			<key>xpos</key>
-			<integer>630</integer>
+			<integer>680</integer>
 			<key>ypos</key>
-			<integer>490</integer>
+			<integer>500</integer>
 		</dict>
 		<key>6B0F6A32-751F-4071-A1E8-76A2E9486962</key>
 		<dict>
@@ -835,6 +911,13 @@ echo $updater-&gt;fetchReleases();
 			<key>ypos</key>
 			<integer>160</integer>
 		</dict>
+		<key>F1565205-CE7B-4880-A3D5-5FAA0609C9C5</key>
+		<dict>
+			<key>xpos</key>
+			<integer>460</integer>
+			<key>ypos</key>
+			<integer>440</integer>
+		</dict>
 		<key>F28D41C6-10B6-447A-9DBB-CD9395F08D69</key>
 		<dict>
 			<key>xpos</key>
@@ -852,7 +935,7 @@ echo $updater-&gt;fetchReleases();
 		<key>youdao_appkey</key>
 		<string></string>
 		<key>youdao_secret</key>
-		<string></string>>
+		<string></string>
 	</dict>
 	<key>variablesdontexport</key>
 	<array>


### PR DESCRIPTION
修改了一些地方：

1. 添加单词我看了一下是有道的接口变了。
2. 接口之前使用的`POST`，我看到现在有道自己用的`GET`。
3. 例外保存之前`Cookie`的方式好像有点问题，登录成功之后，用那个`Cookie`调保存接口始终返回`nouser`。

其实可以直接让`curl`这个库自己维护`Cookie`，不用自己在维护一个`$cookie`变量。
+ `CURLOPT_COOKIEJAR`保存返回的Cookie
+ `CURLOPT_COOKIEFILE`读取现有Cookie

我对`PHP`不是很熟，你看一下改得合不合理。